### PR TITLE
Hotfix: adjust file with new AudioFileSpecSet

### DIFF
--- a/src/wavealign/loudness_processing/align_waveform_to_target.py
+++ b/src/wavealign/loudness_processing/align_waveform_to_target.py
@@ -4,6 +4,6 @@ from wavealign.data_collection.audio_file_spec_set import AudioFileSpecSet
 from wavealign.loudness_processing.calculation import calculate_gain_difference_to_target
 
 
-def align_waveform_to_target(audio_spec_set: AudioFileSpecSet, target_lufs: int):
-    gain_factor = calculate_gain_difference_to_target(audio_spec_set.original_lufs, target_lufs)
-    audio_spec_set.audio_data = np.multiply(audio_spec_set.audio_data, gain_factor)
+def align_waveform_to_target(audio_file_spec_set: AudioFileSpecSet, target_lufs: int):
+    gain_factor = calculate_gain_difference_to_target(audio_file_spec_set.original_lufs, target_lufs)
+    audio_file_spec_set.audio_data = np.multiply(audio_file_spec_set.audio_data, gain_factor)

--- a/src/wavealign/loudness_processing/align_waveform_to_target.py
+++ b/src/wavealign/loudness_processing/align_waveform_to_target.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from wavealign.data_collection.audio_spec_set import AudioSpecSet
+from wavealign.data_collection.audio_file_spec_set import AudioFileSpecSet
 from wavealign.loudness_processing.calculation import calculate_gain_difference_to_target
 
 
-def align_waveform_to_target(audio_spec_set: AudioSpecSet, target_lufs: int):
+def align_waveform_to_target(audio_spec_set: AudioFileSpecSet, target_lufs: int):
     gain_factor = calculate_gain_difference_to_target(audio_spec_set.original_lufs, target_lufs)
     audio_spec_set.audio_data = np.multiply(audio_spec_set.audio_data, gain_factor)


### PR DESCRIPTION
Commit cf31e89 by @SimonZimmer has introduced the AudioFileSpecSet class instead of the old AudioSpecSet class. However this change was not refleced within /loudness_processing/align_waveform_to_target.py which was still using the old AudioSpecSet class.