### PR TITLE
Bug/python311 and pytest fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22.0
+numpy==1.24.3
 pyloudnorm==0.1.1
 music-tag==0.4.3
 ffmpegio==0.8.3

--- a/tests/unit/data_collection/test_metadata_extractor.py
+++ b/tests/unit/data_collection/test_metadata_extractor.py
@@ -45,15 +45,14 @@ class TestMetadataExtractor(unittest.TestCase):
 
 
 class TestMetadataExtractorAssert(unittest.TestCase):
-    @mock.patch('wavealign.data_collection.metadata_extractor.load_file').start()
+    @mock.patch('wavealign.data_collection.metadata_extractor.load_file')
     def test_write_with_faulty_metadata(self, mock_tag_load_file):
         mock_tag_load_file.return_value = None
 
         try:
             MetaDataExtractor().extract('some_path')
-        except ValueError:
-            pass
-        except Exception:
-            self.fail('unexpected exception raised')
+        except Exception as e:
+            if "Failed to read metadata for" not in str(e):
+                self.fail('unexpected exception raised')
         else:
             self.fail('ExpectedException not raised')


### PR DESCRIPTION
The previous numpy version raised errors with python3.11. Since we want to support 3.9 - 3.11 I updated numpy. All tests are running. 
However using pytest I catched an error that did not occur using the builtin unittest discover module:
`E   TypeError: got <MagicMock name='load_file().pytestmark.mark' id='4952738192'> instead of Mark`. This was caused by the way we were patching with mock.patch. We used mock.patch within the decorator syntax, but were calling start() on it as if we were using it within the with statement or as a context manager. This caused the MagicMock object to interfere with pytest's internals. Also we actually checked for a value error within the test. However the metadata extractor raises an exception in case of a value error. I also fixed this. Now all tests are running in python 3.9 and 3.11 using pytest or the built in unittest discover module.