### PR TITLE
Issue/35/yaml cache file always written

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ input/.DS_Store
 input/*.wav
 output/*.wav
 
+# generated files
+.wavealign_cache.yaml

--- a/src/wavealign/data_collection/caching_processor.py
+++ b/src/wavealign/data_collection/caching_processor.py
@@ -5,7 +5,7 @@ import yaml
 class CachingProcessor:
     def __init__(self, cache_path: str):
         self.__cache_path = cache_path
-        self.__cache_signature = "wavealign_cache.yaml"
+        self.__cache_signature = ".wavealign_cache.yaml"
         if not cache_path:
             raise ValueError("Cache path must be provided")
 

--- a/src/wavealign/data_collection/caching_processor.py
+++ b/src/wavealign/data_collection/caching_processor.py
@@ -1,28 +1,25 @@
 import os
-import glob
 import yaml
-import time
 
 
 class CachingProcessor:
     def __init__(self, cache_path: str):
         self.__cache_path = cache_path
         self.__cache_signature = "wavealign_cache.yaml"
+        if not cache_path:
+            raise ValueError("Cache path must be provided")
 
     def read_cache(self) -> dict:
-        cache_files = glob.glob(
-            os.path.join(self.__cache_path, f"*_{self.__cache_signature}")
-        )
-        if cache_files:
-            latest_cache_file = max(cache_files, key=os.path.getctime)
-            with open(latest_cache_file, "r") as cache_file:
-                return yaml.safe_load(cache_file)
-        return {}
+        cache_file_path = os.path.join(self.__cache_path, self.__cache_signature)
+
+        if not os.path.exists(cache_file_path):
+            return {}
+
+        with open(cache_file_path, "r") as cache_file:
+            return yaml.safe_load(cache_file)
 
     def write_cache(self, cache_data: dict) -> None:
-        new_timestamp = time.strftime("%Y%m%d-%H%M%S")
-        cache_path = os.path.join(
-            self.__cache_path, f"{new_timestamp}_{self.__cache_signature}"
-        )
+        cache_path = os.path.join(self.__cache_path, self.__cache_signature)
+
         with open(cache_path, "w") as cache_file:
             yaml.dump(cache_data, cache_file, default_flow_style=False)

--- a/src/wavealign/loudness_processing/audio_property_sets_processor.py
+++ b/src/wavealign/loudness_processing/audio_property_sets_processor.py
@@ -29,7 +29,7 @@ class AudioPropertySetsProcessor:
         audio_property_sets: list[AudioPropertySet],
         target_level: int,
         output_path: str,
-        ) -> dict:
+    ) -> dict:
         for audio_property_set in audio_property_sets:
             if (
                 clipping_detected(
@@ -60,9 +60,9 @@ class AudioPropertySetsProcessor:
                 output, aligned_audio_data, audio_property_set.metadata
             )
 
-            self.__cache_data[
-                audio_property_set.file_path
-            ] = audio_property_set.last_modified
+            self.__cache_data[audio_property_set.file_path] = (
+                audio_property_set.last_modified
+            )
 
         self.__cache_data["target_level"] = target_level
 

--- a/src/wavealign/wave_alignment_processor.py
+++ b/src/wavealign/wave_alignment_processor.py
@@ -6,6 +6,7 @@ from wavealign.loudness_processing.window_size import WindowSize
 from wavealign.loudness_processing.clipping_strategy import ClippingStrategy
 from wavealign.data_collection.caching_processor import CachingProcessor
 from wavealign.data_collection.cache_manager import CacheManager
+from wavealign.data_collection.write_log_file import write_log_file
 from wavealign.utility.ensure_path_exists import ensure_path_exists
 
 
@@ -20,12 +21,15 @@ class WaveAlignmentProcessor:
     ) -> None:
         self.__output_path = output_path
         self.__target_level = target_level
+        self.__log_file_path = output_path if output_path else input_path
         self.__caching_processor = CachingProcessor(cache_path=input_path)
         cache_data = self.__caching_processor.read_cache()
         self.__audio_property_sets_reader = AudioPropertySetsReader(
             input_path=input_path,
             window_size=window_size,
-            cache_manager=CacheManager(cache_data=cache_data, target_level=target_level)
+            cache_manager=CacheManager(
+                cache_data=cache_data, target_level=target_level
+            ),
         )
         self.__audio_property_sets_processor = AudioPropertySetsProcessor(
             cache_data=cache_data, clipping_strategy=clipping_strategy
@@ -33,11 +37,21 @@ class WaveAlignmentProcessor:
 
     def process(self) -> None:
         ensure_path_exists(self.__output_path)
+        cache_data = self.__caching_processor.read_cache()
 
-        audio_property_sets = self.__audio_property_sets_reader.read()
+        audio_property_sets, skipped_files = self.__audio_property_sets_reader.read()
 
-        cache = self.__audio_property_sets_processor.process(
+        clipped_files, cache = self.__audio_property_sets_processor.process(
             audio_property_sets, self.__target_level, self.__output_path
         )
 
-        self.__caching_processor.write_cache(cache)
+        if not (cache == cache_data):
+            self.__caching_processor.write_cache(cache)
+
+        problem_files = skipped_files + clipped_files
+
+        if problem_files:
+            write_log_file(
+                self.__log_file_path,
+                problem_files,
+            )

--- a/src/wavealign/wave_alignment_processor.py
+++ b/src/wavealign/wave_alignment_processor.py
@@ -6,7 +6,6 @@ from wavealign.loudness_processing.window_size import WindowSize
 from wavealign.loudness_processing.clipping_strategy import ClippingStrategy
 from wavealign.data_collection.caching_processor import CachingProcessor
 from wavealign.data_collection.cache_manager import CacheManager
-from wavealign.data_collection.write_log_file import write_log_file
 from wavealign.utility.ensure_path_exists import ensure_path_exists
 
 
@@ -21,7 +20,6 @@ class WaveAlignmentProcessor:
     ) -> None:
         self.__output_path = output_path
         self.__target_level = target_level
-        self.__log_file_path = output_path if output_path else input_path
         self.__caching_processor = CachingProcessor(cache_path=input_path)
         cache_data = self.__caching_processor.read_cache()
         self.__audio_property_sets_reader = AudioPropertySetsReader(
@@ -39,19 +37,11 @@ class WaveAlignmentProcessor:
         ensure_path_exists(self.__output_path)
         cache_data = self.__caching_processor.read_cache()
 
-        audio_property_sets, skipped_files = self.__audio_property_sets_reader.read()
+        audio_property_sets = self.__audio_property_sets_reader.read()
 
-        clipped_files, cache = self.__audio_property_sets_processor.process(
+        cache = self.__audio_property_sets_processor.process(
             audio_property_sets, self.__target_level, self.__output_path
         )
 
         if not (cache == cache_data):
             self.__caching_processor.write_cache(cache)
-
-        problem_files = skipped_files + clipped_files
-
-        if problem_files:
-            write_log_file(
-                self.__log_file_path,
-                problem_files,
-            )

--- a/tests/integration/test_wave_alignment_processor.py
+++ b/tests/integration/test_wave_alignment_processor.py
@@ -92,7 +92,6 @@ class TestWaveAlignmentProcessor(unittest.TestCase):
         except Exception as e:
             self.fail(f"Raised the following excepton {e}")
 
-
 def get_file_paths_with_ending(directory: str, ending: str):
     file_paths = []
     for root, _, files in os.walk(directory):

--- a/tests/unit/data_collection/test_caching_processor.py
+++ b/tests/unit/data_collection/test_caching_processor.py
@@ -6,7 +6,7 @@ from wavealign.data_collection.caching_processor import CachingProcessor
 
 
 class TestCachingProcessor(unittest.TestCase):
-    @mock.patch("os.path.exists")
+    @mock.patch("wavealign.data_collection.caching_processor.os.path.exists")
     def test_read_cache_non_existent(self, mock_exists):
         mock_exists.return_value = False
 
@@ -15,15 +15,15 @@ class TestCachingProcessor(unittest.TestCase):
         self.assertEqual(result, {})
 
     @mock.patch("builtins.open", new_callable=mock_open, read_data="key: value\n")
-    @mock.patch("wavealign.data_collection.caching_processor.os.path.exists")
+    @mock.patch("os.path.exists")
     @mock.patch("wavealign.data_collection.caching_processor.yaml.safe_load")
     def test_read_cache_exists(self, mock_yaml_load, mock_exists, mock_open):
         mock_exists.return_value = True
 
         result = CachingProcessor("/fake/path").read_cache()
 
-        mock_yaml_load.assert_called_once_with(mock_open())
         self.assertEqual(result, mock_yaml_load.return_value)
+        mock_yaml_load.assert_called_once_with(mock_open())
 
     @mock.patch("builtins.open", new_callable=mock_open)
     @mock.patch("wavealign.data_collection.caching_processor.yaml.dump")

--- a/tests/unit/data_collection/test_caching_processor.py
+++ b/tests/unit/data_collection/test_caching_processor.py
@@ -1,0 +1,41 @@
+import unittest
+import mock
+
+from unittest.mock import mock_open
+from wavealign.data_collection.caching_processor import CachingProcessor
+
+
+class TestCachingProcessor(unittest.TestCase):
+    @mock.patch("os.path.exists")
+    def test_read_cache_non_existent(self, mock_exists):
+        mock_exists.return_value = False
+
+        result = CachingProcessor("/fake/path").read_cache()
+
+        self.assertEqual(result, {})
+
+    @mock.patch("builtins.open", new_callable=mock_open, read_data="key: value\n")
+    @mock.patch("wavealign.data_collection.caching_processor.os.path.exists")
+    @mock.patch("wavealign.data_collection.caching_processor.yaml.safe_load")
+    def test_read_cache_exists(self, mock_yaml_load, mock_exists, mock_open):
+        mock_exists.return_value = True
+
+        result = CachingProcessor("/fake/path").read_cache()
+
+        mock_yaml_load.assert_called_once_with(mock_open())
+        self.assertEqual(result, mock_yaml_load.return_value)
+
+    @mock.patch("builtins.open", new_callable=mock_open)
+    @mock.patch("wavealign.data_collection.caching_processor.yaml.dump")
+    def test_write_cache(self, mock_yaml_dump, mock_open):
+        cache_data = {"key": "value"}
+        CachingProcessor("/fake/path").write_cache(cache_data)
+
+        mock_open.assert_called_once_with("/fake/path/wavealign_cache.yaml", "w")
+        mock_yaml_dump.assert_called_with(
+            cache_data, mock_open(), default_flow_style=False
+        )
+
+    def test_init_no_cache_path(self):
+        with self.assertRaises(ValueError):
+            CachingProcessor("")

--- a/tests/unit/data_collection/test_caching_processor.py
+++ b/tests/unit/data_collection/test_caching_processor.py
@@ -31,7 +31,7 @@ class TestCachingProcessor(unittest.TestCase):
         cache_data = {"key": "value"}
         CachingProcessor("/fake/path").write_cache(cache_data)
 
-        mock_open.assert_called_once_with("/fake/path/wavealign_cache.yaml", "w")
+        mock_open.assert_called_once_with("/fake/path/.wavealign_cache.yaml", "w")
         mock_yaml_dump.assert_called_with(
             cache_data, mock_open(), default_flow_style=False
         )

--- a/tests/unit/wavealign/test_wave_alignment_processor.py
+++ b/tests/unit/wavealign/test_wave_alignment_processor.py
@@ -10,6 +10,7 @@ from wavealign.loudness_processing.audio_property_sets_processor import (
 from wavealign.wave_alignment_processor import (
     WaveAlignmentProcessor,
 )
+
 # TODO: use mock.patch.object also for other tests (seems cleaner)
 
 
@@ -18,16 +19,22 @@ class TestWaveAlignmentProcessor(unittest.TestCase):
         self.mock_read_cache = mock.patch.object(
             CachingProcessor, "read_cache", return_value={}
         ).start()
-        self.mock_write_cache = mock.patch.object(CachingProcessor, "write_cache").start()
+        self.mock_write_cache = mock.patch.object(
+            CachingProcessor, "write_cache"
+        ).start()
         self.mock_audio_read = mock.patch.object(
-            AudioPropertySetsReader, "read", return_value=([])
+            AudioPropertySetsReader, "read", return_value=([], [])
         ).start()
         self.mock_audio_process = mock.patch.object(
-            AudioPropertySetsProcessor, "process", return_value=({})
+            AudioPropertySetsProcessor, "process", return_value=([], {})
         ).start()
         self.mock_ensure_path_exists = mock.patch(
             "wavealign.wave_alignment_processor.ensure_path_exists"
         ).start()
+        self.mock_write_log_file = mock.patch(
+            "wavealign.wave_alignment_processor.write_log_file"
+        ).start()
+        self.mock_read_cache.return_value = {"file1": 123}
 
         self.processor = WaveAlignmentProcessor(
             input_path="input_path",
@@ -44,6 +51,37 @@ class TestWaveAlignmentProcessor(unittest.TestCase):
         self.processor.process()
 
         self.mock_ensure_path_exists.assert_called_once_with("output_path")
+        self.assertTrue(self.mock_read_cache.call_count, 2)
         self.mock_audio_read.assert_called_once()
         self.mock_audio_process.assert_called_once_with([], 10, "output_path")
-        self.mock_write_cache.assert_called_once_with({})
+        self.mock_write_cache.assert_called_once()
+        self.mock_write_log_file.assert_not_called()
+
+    def test_process_with_problem_files(self):
+        self.mock_audio_read.return_value = ([], ["file1"])
+        self.mock_audio_process.return_value = (["file2"], {})
+
+        self.processor.process()
+
+        self.mock_ensure_path_exists.assert_called_once_with("output_path")
+        self.mock_audio_read.assert_called_once()
+        self.mock_audio_process.assert_called_once_with([], 10, "output_path")
+        self.mock_write_cache.assert_called_once()
+
+        self.mock_write_log_file.assert_called_once_with(
+            "output_path", ["file1", "file2"]
+        )
+
+    def test_process_same_cache(self):
+        self.mock_audio_process.return_value = [[], {"file1": 123}]
+
+        self.processor.process()
+
+        self.mock_write_cache.assert_not_called()
+
+    def test_process_cache_changed(self):
+        self.mock_audio_process.return_value = [[], {"file2": 456}]
+
+        self.processor.process()
+
+        self.mock_write_cache.assert_called_once()

--- a/tests/unit/wavealign/test_wave_alignment_processor.py
+++ b/tests/unit/wavealign/test_wave_alignment_processor.py
@@ -23,16 +23,13 @@ class TestWaveAlignmentProcessor(unittest.TestCase):
             CachingProcessor, "write_cache"
         ).start()
         self.mock_audio_read = mock.patch.object(
-            AudioPropertySetsReader, "read", return_value=([], [])
+            AudioPropertySetsReader, "read", return_value=([])
         ).start()
         self.mock_audio_process = mock.patch.object(
-            AudioPropertySetsProcessor, "process", return_value=([], {})
+            AudioPropertySetsProcessor, "process", return_value=({})
         ).start()
         self.mock_ensure_path_exists = mock.patch(
             "wavealign.wave_alignment_processor.ensure_path_exists"
-        ).start()
-        self.mock_write_log_file = mock.patch(
-            "wavealign.wave_alignment_processor.write_log_file"
         ).start()
         self.mock_read_cache.return_value = {"file1": 123}
 
@@ -55,32 +52,16 @@ class TestWaveAlignmentProcessor(unittest.TestCase):
         self.mock_audio_read.assert_called_once()
         self.mock_audio_process.assert_called_once_with([], 10, "output_path")
         self.mock_write_cache.assert_called_once()
-        self.mock_write_log_file.assert_not_called()
-
-    def test_process_with_problem_files(self):
-        self.mock_audio_read.return_value = ([], ["file1"])
-        self.mock_audio_process.return_value = (["file2"], {})
-
-        self.processor.process()
-
-        self.mock_ensure_path_exists.assert_called_once_with("output_path")
-        self.mock_audio_read.assert_called_once()
-        self.mock_audio_process.assert_called_once_with([], 10, "output_path")
-        self.mock_write_cache.assert_called_once()
-
-        self.mock_write_log_file.assert_called_once_with(
-            "output_path", ["file1", "file2"]
-        )
 
     def test_process_same_cache(self):
-        self.mock_audio_process.return_value = [[], {"file1": 123}]
+        self.mock_audio_process.return_value = {"file1": 123}
 
         self.processor.process()
 
         self.mock_write_cache.assert_not_called()
 
     def test_process_cache_changed(self):
-        self.mock_audio_process.return_value = [[], {"file2": 456}]
+        self.mock_audio_process.return_value = {"file2": 456}
 
         self.processor.process()
 


### PR DESCRIPTION
Makes it so that there is always only a single cache file per target directory.

Additionally:
* Remove timestamps and the option for multiple cache files in general to reduce complexity. (Let me know if there is a reason we need multiples)
* Remove the failing mp3 integration test that became irrelevant
* Make cache file hidden, so the user doesn't accidentally move/copy it around
* Add missing tests for `CachingProcessor`