### PR TITLE
removed metadata check issue #36

### DIFF
--- a/src/wavealign/data_collection/metadata_extractor.py
+++ b/src/wavealign/data_collection/metadata_extractor.py
@@ -9,24 +9,18 @@ class MetaDataExtractor:
         self,
         file_path: str,
     ) -> AudioMetadata:
-        try:
-            metadata = File(file_path)
-            if metadata is None:
-                raise ValueError
+        metadata = File(file_path)
+        full_details = probe.full_details(file_path)
+        audio_stream_metadata = full_details["streams"][0]
+        bit_rate = self.__get_bitrate_specifier(audio_stream_metadata["bit_rate"])
 
-            full_details = probe.full_details(file_path)
-            audio_stream_metadata = full_details["streams"][0]
-            bit_rate = self.__get_bitrate_specifier(audio_stream_metadata["bit_rate"])
-
-            return AudioMetadata(
-                num_channels=audio_stream_metadata["channels"],
-                metadata=metadata,
-                codec_name=audio_stream_metadata["codec_name"],
-                bit_rate=bit_rate,
-                sample_rate=audio_stream_metadata["sample_rate"],
-            )
-        except ValueError:
-            raise Exception(f"Failed to read metadata for {file_path}")
+        return AudioMetadata(
+            num_channels=audio_stream_metadata["channels"],
+            metadata=metadata,
+            codec_name=audio_stream_metadata["codec_name"],
+            bit_rate=bit_rate,
+            sample_rate=audio_stream_metadata["sample_rate"],
+        )
 
     @staticmethod
     def __get_bitrate_specifier(bit_rate: int) -> str:

--- a/tests/unit/data_collection/test_metadata_extractor.py
+++ b/tests/unit/data_collection/test_metadata_extractor.py
@@ -43,17 +43,3 @@ class TestMetadataExtractor(unittest.TestCase):
             sample_rate=44100,
         )
         self.assertEqual(expect.__repr__(), metadata.__repr__())
-
-
-class TestMetadataExtractorAssert(unittest.TestCase):
-    @mock.patch("wavealign.data_collection.metadata_extractor.File")
-    def test_write_with_faulty_metadata(self, mock_mutagen_file):
-        mock_mutagen_file.return_value = None
-
-        try:
-            MetaDataExtractor().extract("some_path")
-        except Exception as e:
-            if "Failed to read metadata for" not in str(e):
-                self.fail("unexpected exception raised")
-        else:
-            self.fail("ExpectedException not raised")


### PR DESCRIPTION
as suggested by @SimonZimmer removed the check if metadatadata was read via mutagen, because a compatible filetype check was already done in `data_colletion/audio_file_finder.py`.

For more info on the discussion see issue #36 